### PR TITLE
Fix links in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,8 +19,8 @@
 					The batch tool can operate the same way on multiple files quickly, making it useful to experienced users with larger needs.<br/><br/>
 
 					<b>Participate</b><br/>
-					To see the full project page with ongoing, unreleased developments, go to <a href="www.github.com/dylan-thinnes/svgtojs">dylan-thinnes/svgtojs</a>.<br/>
-					To see the source for the latest release which composes this website, go to <a href="www.github.com/svgtojs/svgtojs.github.io">svgtojs/svgtojs.github.io</a>.
+					To see the full project page with ongoing, unreleased developments, go to <a href="https://www.github.com/dylan-thinnes/svgtojs">dylan-thinnes/svgtojs</a>.<br/>
+					To see the source for the latest release which composes this website, go to <a href="https://www.github.com/svgtojs/svgtojs.github.io">svgtojs/svgtojs.github.io</a>.
 					</div>
 					<!-- <div class="buttons">
 						<a class="button dynamic largeWidth" id="singleMode">To Copy-Paste Tool<br/>(Beginner)</a>


### PR DESCRIPTION
`www` as the beginning of the web address causes the link to point to
a subdirectory of the webpage. `https://www` fixes this issue.